### PR TITLE
Fix: writing dat.json

### DIFF
--- a/codec.js
+++ b/codec.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const debug = require('debug')('p2pcommons')
+const debug = require('debug')('p2pcommons:codec')
 const { Type } = require('@avro/types')
 const GenericType = require('./schemas/generic.json')
 const DBItemType = require('./schemas/dbitem.json')

--- a/lib/dat-helper.js
+++ b/lib/dat-helper.js
@@ -1,6 +1,8 @@
 // Note(dk): this file contents should be replaced-by/combine-with dat-sdk in medium-term
 const assert = require('assert')
-const debug = require('debug')('p2pcommons')
+const { normalize } = require('path')
+const debug = require('debug')('p2pcommons:dathelper')
+const mirror = require('mirror-folder')
 const Hyperdrive = require('@geut/hyperdrive-promise')
 const corestore = require('corestore')
 const Storage = require('universal-dat-storage')
@@ -11,13 +13,12 @@ const DEFAULT_DRIVE_OPTS = {
   latest: false
 }
 
-const create = (location, opts = {}) => {
+const create = (location, key = null, opts = {}) => {
   assert.ok(location, 'directory or storage required')
   assert.strictEqual(typeof opts, 'object', 'opts should be type object')
   debug('DatHelper:constructor location', location)
   debug('DatHelper:constructor opts', opts)
   const storage = Storage(Object.assign({}, opts.storageOpts))
-  const key = null
   const hOpts = Object.assign(DEFAULT_DRIVE_OPTS, opts.hyperdrive)
 
   let driveStorage
@@ -27,14 +28,50 @@ const create = (location, opts = {}) => {
   } else if (opts.storageFn) {
     driveStorage = opts.storageFn(location)
   } else {
-    driveStorage = corestore(
-      storage.getCoreStore(`cores-${location}`),
-      opts.corestoreOpts
-    )
+    driveStorage = corestore(storage.getCoreStore('.dat'), opts.corestoreOpts)
   }
 
   debug('DatHelper: driveStorage', driveStorage)
-  return Hyperdrive(driveStorage, key, hOpts)
+  const drive = Hyperdrive(driveStorage, key, hOpts)
+
+  return drive
+}
+
+const importFiles = async (archive, src = './', opts = {}) => {
+  assert.ok(archive, 'archive is required')
+  const equals = (src, dst, cb) => {
+    // Note(dk): this is necessary because latest hyperdrive is using Hyperdrive-schemas
+    // which already resolves the getTime on the mtime value.
+    if (!src.stat.isDirectory() && src.stat.size !== dst.stat.size) {
+      return cb(null, false)
+    }
+    if (src.stat.mtime.getTime() > dst.stat.mtime) return cb(null, false)
+    cb(null, true)
+  }
+  const finalOpts = {
+    watch: false,
+    dereference: true,
+    count: true,
+    equals,
+    ...opts
+  }
+
+  if (finalOpts.watch || finalOpts.ee) {
+    // returns an event emitter
+    return mirror(normalize(src), { name: '/', fs: archive }, finalOpts)
+  }
+  return new Promise((resolve, reject) => {
+    // NOTE(dk): this can be/feel slow if content is big.
+    mirror(
+      normalize(src),
+      { name: '/', fs: archive },
+      finalOpts,
+      (err, data) => {
+        if (err) return reject(err)
+        resolve(data)
+      }
+    )
+  })
 }
 
 const open = (location, opts = {}) => {
@@ -45,5 +82,6 @@ const open = (location, opts = {}) => {
 
 module.exports = {
   create,
+  importFiles,
   open
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -822,11 +822,6 @@
         }
       }
     },
-    "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
-    },
     "cuid": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/cuid/-/cuid-1.3.8.tgz",
@@ -1827,6 +1822,48 @@
       "requires": {
         "napi-macros": "^1.8.2",
         "node-gyp-build": "^3.8.0"
+      }
+    },
+    "fd-read-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-read-stream/-/fd-read-stream-1.1.0.tgz",
+      "integrity": "sha1-0wPMv+4CqaVqNJP7CLy1lpGqU7E=",
+      "requires": {
+        "readable-stream": "^2.2.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "figures": {
@@ -3283,6 +3320,15 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "mirror-folder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mirror-folder/-/mirror-folder-3.0.0.tgz",
+      "integrity": "sha512-fh6wDXcSpFoKY7ZPHnEv1+xjLOS7tlkEpTvl4Y6ZsT0HNjIaYg6ktq9ng8MPthFruunS8D/3GnPeaWhoQD3X9g==",
+      "requires": {
+        "fd-read-stream": "^1.1.0",
+        "recursive-watch": "^1.1.1"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -4180,6 +4226,14 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "recursive-watch": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz",
+      "integrity": "sha512-fWejAmdLi7B/jipBUjTLnqId+PK+573fbGNbdaNA/AiAnQAx6OYOLCGWRs0W5+PyM1rLzZSWK2f40QpHSR49PQ==",
+      "requires": {
+        "ttl": "^1.3.0"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -5070,6 +5124,11 @@
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
+    "ttl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ttl/-/ttl-1.3.1.tgz",
+      "integrity": "sha512-+bGy9iDAqg3WSfc2ZrprToSPJhZjqy7vUv9wupQzsiv+BVPVx1T2a6G4T0290SpQj+56Toaw9BiLO5j5Bd7QzA=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -5105,14 +5164,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
-    "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "requires": {
-        "crypto-random-string": "^2.0.0"
-      }
     },
     "universal-dat-storage": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
     "dat-encoding": "^5.0.1",
     "env-paths": "^2.2.0",
     "fs-extra": "^7.0.1",
+    "hypercore-crypto": "^1.0.0",
     "hyperdiscovery": "^10.1.0",
     "level": "^5.0.1",
     "level-auto-index": "geut/level-auto-index",
+    "mirror-folder": "^3.0.0",
     "random-access-memory": "^3.1.1",
     "subleveldown": "^4.1.4",
-    "unique-string": "^2.0.0",
     "universal-dat-storage": "^1.3.5"
   },
   "devDependencies": {

--- a/tests/index.js
+++ b/tests/index.js
@@ -25,7 +25,10 @@ test('init: create content module', async t => {
   t.same(output.title, metadata.title)
   t.same(output.description, metadata.description)
   t.ok(Buffer.isBuffer(output.url))
-  t.same(output.license, '')
+  t.same(
+    output.license,
+    'https://creativecommons.org/publicdomain/zero/1.0/legalcode'
+  )
   t.same(output.authors, [])
   t.same(output.parents, [])
   t.end()
@@ -48,7 +51,10 @@ test('init: create profile module', async t => {
   t.same(output.title, metadata.title)
   t.same(output.description, metadata.description)
   t.ok(Buffer.isBuffer(output.url))
-  t.same(output.license, '')
+  t.same(
+    output.license,
+    'https://creativecommons.org/publicdomain/zero/1.0/legalcode'
+  )
   t.same(output.follows, [])
   t.same(output.contents, [])
   t.end()


### PR DESCRIPTION
This PR should improve the functionality of the `init` method. After an `init` method call, it was expected to have the following:
- a new folder with a _hash_ name
- a dat.json with valid metadata inside
Something like this:
`~/.p2pcommons/hash/dat.json` This was missing.

Inside this folder there was also some dat related metadata. This is now stored under a `.dat/` folder inside. The content of such dir is created using [corestore](https://github.com/andrewosh/corestore/tree/663e8847e0fa2ceb9c04db30970b11baba53de71)

This also closes #11 allowing a buffer as the key param.

Also, we are now placing the `db` in the same `~/.p2pcommons` folder. This destination can be changed by using the `dbpath` option.
