### PR TITLE
Fix: remove corestore output after writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,11 +249,19 @@ class SDK {
     )
 
     const datJSONDir = join(this.baseDir, metadata.url.toString('hex'))
-    const archive = dat.open(datJSONDir)
+    const storageOpts = {
+      storageLocation: join(this.baseDir, metadata.url.toString('hex'))
+    }
+    const archive = dat.open(
+      metadata.url.toString('hex'),
+      undefined,
+      storageOpts
+    )
     await archive.ready()
     let stat
     if (isWritable) {
-      await archive.writeFile('dat.json', JSON.stringify(metadata))
+      await writeFile(join(datJSONDir, 'dat.json'), JSON.stringify(metadata))
+      await dat.importFiles(archive, datJSONDir)
       stat = await archive.stat('/dat.json')
     }
 

--- a/lib/dat-helper.js
+++ b/lib/dat-helper.js
@@ -13,24 +13,43 @@ const DEFAULT_DRIVE_OPTS = {
   latest: false
 }
 
+const getDriveStorage = ({
+  location,
+  storageOpts,
+  corestoreOpts,
+  storageFn,
+  persist = true
+}) => {
+  const storage = Storage(storageOpts)
+
+  let driveStorage
+
+  if (!persist) {
+    driveStorage = RAM
+  } else if (storageFn) {
+    driveStorage = storageFn(location)
+  } else {
+    driveStorage = corestore(storage.getCoreStore('.dat'), corestoreOpts)
+  }
+
+  return driveStorage
+}
+
+// NOTE(dk): this can be used to get or create.
 const create = (location, key = null, opts = {}) => {
   assert.ok(location, 'directory or storage required')
   assert.strictEqual(typeof opts, 'object', 'opts should be type object')
   debug('DatHelper:constructor location', location)
   debug('DatHelper:constructor opts', opts)
-  const storage = Storage(Object.assign({}, opts.storageOpts))
   const hOpts = Object.assign(DEFAULT_DRIVE_OPTS, opts.hyperdrive)
 
-  let driveStorage
-
-  if (!opts.persist) {
-    driveStorage = RAM
-  } else if (opts.storageFn) {
-    driveStorage = opts.storageFn(location)
-  } else {
-    driveStorage = corestore(storage.getCoreStore('.dat'), opts.corestoreOpts)
-  }
-
+  const driveStorage = getDriveStorage({
+    location,
+    storageOpts: opts.storageOpts,
+    persist: opts.persist,
+    corestoreOpts: opts.corestoreOpts,
+    storageFn: opts.storageFn
+  })
   debug('DatHelper: driveStorage', driveStorage)
   const drive = Hyperdrive(driveStorage, key, hOpts)
 
@@ -74,10 +93,11 @@ const importFiles = async (archive, src = './', opts = {}) => {
   })
 }
 
-const open = (location, opts = {}) => {
+const open = (key, location, storageOpts = {}) => {
   // NOTE(dk): location can be a path or a dat url
-  assert.ok(location, 'location is required')
-  return Hyperdrive(location, opts)
+  assert.ok(key, 'key is required')
+  const driveStorage = getDriveStorage({ storageOpts, location })
+  return Hyperdrive(driveStorage, key)
 }
 
 module.exports = {

--- a/tests/index.js
+++ b/tests/index.js
@@ -116,6 +116,36 @@ test('set: update a value', async t => {
   await p2p.destroy()
 })
 
+test('update: check version change', async t => {
+  const p2p = createDb()
+  await p2p.ready()
+  const sampleData = {
+    type: 'content',
+    title: 'demo',
+    description: 'lorem ipsum'
+  }
+  const metadata = await p2p.init(sampleData)
+  const key = metadata.url.toString('hex')
+
+  const result1 = await p2p.get(key, false)
+
+  metadata.description = 'A more accurate description'
+  await p2p.set(metadata)
+  const result2 = await p2p.get(key, false)
+
+  t.same(result2.rawJSON.description, metadata.description)
+  t.ok(
+    result2.version > result1.version,
+    'latest version should be bigger than previous version after update'
+  )
+  t.ok(
+    result2.lastModified > result1.lastModified,
+    'lastModified should be bigger than previous lastModified'
+  )
+  t.end()
+  await p2p.destroy()
+})
+
 test('list content', async t => {
   const p2p = createDb()
   await p2p.ready()


### PR DESCRIPTION
This  PR closes #17

It also adds a test for checking stored version bumps (externally managed by hypertrie)