### PR TITLE
new feature: list modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Returns an array containing all the `content` modules saved in the local db.
 
 Returns an array containing all the `profile` modules saved in the local db.
 
+### list
+
+> _async_ `list()`
+
+Returns an array containing all the modules saved in the local db.
+
 ### openFile
 
 > _async_ `openFile(key: string)`

--- a/index.js
+++ b/index.js
@@ -378,6 +378,18 @@ class SDK {
     })
   }
 
+  async list () {
+    return new Promise((resolve, reject) => {
+      const out = []
+      const s = this.localdb.createValueStream()
+      s.on('data', val => {
+        if (val.isWritable) out.push(val)
+      })
+      s.on('end', () => resolve(out))
+      s.on('error', reject)
+    })
+  }
+
   async openFile (key) {
     assert.strictEqual(typeof key, 'string', 'key is required')
     const { main } = await this.get(key)

--- a/tests/index.js
+++ b/tests/index.js
@@ -205,3 +205,27 @@ test('list profiles', async t => {
   t.end()
   await p2p.destroy()
 })
+
+test('list modules', async t => {
+  const p2p = createDb()
+  await p2p.ready()
+  const sampleData = [
+    {
+      type: 'content',
+      title: 'demo',
+      description: 'lorem ipsum'
+    },
+    {
+      type: 'content',
+      title: 'demo 2'
+    },
+    { type: 'content', title: 'sample' },
+    { type: 'profile', title: 'Professor X' }
+  ]
+
+  await Promise.all([].concat(sampleData).map(d => p2p.init(d)))
+  const result = await p2p.list()
+  t.same(result.length, sampleData.length)
+  t.end()
+  await p2p.destroy()
+})


### PR DESCRIPTION
This PR closes #15 
It adds a new function called `list` that returns an array containing all the modules saved in the local db.