### PR TITLE
Update: sdk now exports and throws custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,18 @@ Used to obtain a file descriptor from the `main` file of a module.
 
 Closes the swarm instance (if created) and the local db.
 
+## Errors
 
+The SDK exports some custom errors: `SDK.errors`
+
+### ValidationError
+
+Indicates there is a difference between what is expected and what was received
+
+### InvalidKeyError
+
+Some keys are _read only_. This error indicates the user is trying to modificate a read only property.
+
+### MissingParam
+
+A more general error, used to indicate if something is missing.

--- a/codec.js
+++ b/codec.js
@@ -1,12 +1,13 @@
-const assert = require('assert')
 const debug = require('debug')('p2pcommons:codec')
+const assert = require('nanocustomassert')
 const { Type } = require('@avro/types')
 const GenericType = require('./schemas/generic.json')
 const DBItemType = require('./schemas/dbitem.json')
+const { MissingParam, ValidationError } = require('./lib/errors')
 
 class Codec {
   constructor (registry) {
-    assert.ok(registry, 'registry is required')
+    assert(registry, MissingParam, 'registry')
     Type.forSchema(GenericType, { registry })
     Type.forSchema(DBItemType, { registry })
     this.registry = registry
@@ -16,20 +17,18 @@ class Codec {
 
   encode (obj) {
     debug('p2pcommons:Codec:encode', obj)
-    assert.strictEqual(
-      typeof obj,
+    assert(typeof obj === 'object', ValidationError, 'object', obj)
+    assert(
+      typeof obj.rawJSON === 'object',
+      ValidationError,
       'object',
-      `Expected an object. Received: ${obj}`
+      obj.rawJSON
     )
-    assert.strictEqual(
-      typeof obj.rawJSON,
-      'object',
-      'Missing property: rawJSON'
-    )
-    assert.strictEqual(
-      typeof obj.rawJSON.type,
+    assert(
+      typeof obj.rawJSON.type === 'string',
+      ValidationError,
       'string',
-      'Missing property: rawJSON.type'
+      obj.rawJSON.type
     )
 
     const newVal = this.registry[obj.avroType].toBuffer(obj.rawJSON)
@@ -49,7 +48,7 @@ class Codec {
 
   decode (buf) {
     debug('p2pcommons:Codec:decode')
-    assert.ok(buf, 'buffer is required')
+    assert(buf, MissingParam, 'buf')
     const dbitem = this.decodeGeneric(buf)
     debug('p2pcommons:Codec:decode dbitem', dbitem)
 

--- a/example.js
+++ b/example.js
@@ -28,11 +28,11 @@ process.once('SIGINT', () => commons.destroy())
   const out = await commons.get(key)
   console.log(`Retrieved type: ${out.type}`)
 
-  out.title = 'Sample Content'
-  out.description = 'This is a short abstract about nothing'
+  const title = 'Sample Content'
+  const description = 'This is a short abstract about nothing'
 
   console.log('Updating content...')
-  await commons.set(out)
+  await commons.set({ url: key, title, description })
 
   // check out updated value from local db
   const result = await commons.get(key)

--- a/index.js
+++ b/index.js
@@ -17,7 +17,11 @@ const dat = require('./lib/dat-helper')
 const Codec = require('./codec')
 const ContentSchema = require('./schemas/content.json')
 const ProfileSchema = require('./schemas/profile.json')
-const { InvalidKeyError, ValidationError } = require('./lib/errors')
+const {
+  InvalidKeyError,
+  ValidationError,
+  MissingParam
+} = require('./lib/errors')
 
 const DEFAULT_SWARM_OPTS = {
   extensions: []
@@ -406,8 +410,6 @@ class SDK {
   }
 }
 
-SDK.errors = { ValidationError, InvalidKeyError }
+SDK.errors = { ValidationError, InvalidKeyError, MissingParam }
 
 module.exports = SDK
-
-exports.errors = { ValidationError, InvalidKeyError }

--- a/lib/dat-helper.js
+++ b/lib/dat-helper.js
@@ -1,12 +1,13 @@
 // Note(dk): this file contents should be replaced-by/combine-with dat-sdk in medium-term
-const assert = require('assert')
 const { normalize } = require('path')
 const debug = require('debug')('p2pcommons:dathelper')
+const assert = require('nanocustomassert')
 const mirror = require('mirror-folder')
 const Hyperdrive = require('@geut/hyperdrive-promise')
 const corestore = require('corestore')
 const Storage = require('universal-dat-storage')
 const RAM = require('random-access-memory')
+const { ValidationError } = require('./errors')
 
 const DEFAULT_DRIVE_OPTS = {
   sparse: true,
@@ -37,10 +38,10 @@ const getDriveStorage = ({
 
 // NOTE(dk): this can be used to get or create.
 const create = (location, key = null, opts = {}) => {
-  assert.ok(location, 'directory or storage required')
-  assert.strictEqual(typeof opts, 'object', 'opts should be type object')
-  debug('DatHelper:constructor location', location)
-  debug('DatHelper:constructor opts', opts)
+  assert(typeof location === 'string', ValidationError, 'string', location)
+  assert(typeof opts === 'object', ValidationError, 'object', opts)
+  debug('create location', location)
+  debug('create opts', opts)
   const hOpts = Object.assign(DEFAULT_DRIVE_OPTS, opts.hyperdrive)
 
   const driveStorage = getDriveStorage({
@@ -50,14 +51,14 @@ const create = (location, key = null, opts = {}) => {
     corestoreOpts: opts.corestoreOpts,
     storageFn: opts.storageFn
   })
-  debug('DatHelper: driveStorage', driveStorage)
+  debug('driveStorage', driveStorage)
   const drive = Hyperdrive(driveStorage, key, hOpts)
 
   return drive
 }
 
 const importFiles = async (archive, src = './', opts = {}) => {
-  assert.ok(archive, 'archive is required')
+  assert(typeof archive === 'object', ValidationError, 'object', archive)
   const equals = (src, dst, cb) => {
     // Note(dk): this is necessary because latest hyperdrive is using Hyperdrive-schemas
     // which already resolves the getTime on the mtime value.
@@ -95,7 +96,12 @@ const importFiles = async (archive, src = './', opts = {}) => {
 
 const open = (key, location, storageOpts = {}) => {
   // NOTE(dk): location can be a path or a dat url
-  assert.ok(key, 'key is required')
+  assert(
+    typeof key === 'string' || Buffer.isBuffer(key),
+    ValidationError,
+    "'string' or Buffer",
+    key
+  )
   const driveStorage = getDriveStorage({ storageOpts, location })
   return Hyperdrive(driveStorage, key)
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,10 @@
+const customError = require('nanoerror')
+
+exports.InvalidKeyError = customError('InvalidKeyError', 'Invalid key: %s')
+
+exports.ValidationError = customError(
+  'ValidationError',
+  'Expected: %s - Received: %s'
+)
+
+exports.MissingParam = customError('MissingParam', 'Missing parameter: %s')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
-const assert = require('assert')
+const assert = require('nanocustomassert')
+const { ValidationError } = require('./errors')
 
 exports.hashShort = x => {
   const p = x.substr(0, 3)
@@ -46,7 +47,7 @@ const JSONencode = (exports.JSONencode = obj => {
 
 const JSONdecode = (exports.JSONdecode = str => {
   if (Buffer.isBuffer(str)) return JSONdecode(JSONencode(str))
-  assert.strictEqual(typeof str, 'string', 'Not a string')
+  assert(typeof str === 'string', ValidationError, 'string', str)
 
   const transform = {
     url: value => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3457,6 +3457,19 @@
       "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
       "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
     },
+    "nanocustomassert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nanocustomassert/-/nanocustomassert-1.0.0.tgz",
+      "integrity": "sha512-oIezVMlrrzPkCtK32NM5y4gU7JPi12NPWrIsXLyH7KL2D3IFYCtNEHSNgabBzoXCMkXI8AO6SMBUSPvJVf6NCA=="
+    },
+    "nanoerror": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nanoerror/-/nanoerror-1.0.0.tgz",
+      "integrity": "sha512-N70Afk4+k0WFQBzBxbMoHXKxxcgFiQ6CQ75NTYgCX9hTNDLRK04ecVCEqCtfEeq42+cEX14lNEZLkf3qo7PzSQ==",
+      "requires": {
+        "quick-format-unescaped": "^3.0.3"
+      }
+    },
     "nanoguard": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/nanoguard/-/nanoguard-1.2.1.tgz",
@@ -4042,6 +4055,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
     },
     "random-access-chrome-file": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "level": "^5.0.1",
     "level-auto-index": "geut/level-auto-index",
     "mirror-folder": "^3.0.0",
+    "nanocustomassert": "^1.0.0",
+    "nanoerror": "^1.0.0",
     "random-access-memory": "^3.1.1",
     "subleveldown": "^4.1.4",
     "universal-dat-storage": "^1.3.5"

--- a/tests/index.js
+++ b/tests/index.js
@@ -39,7 +39,7 @@ test('init: create content module', async t => {
   await p2p.destroy()
 })
 
-test('init: creation should fail due to missing params', async t => {
+test('init: creation should throw a ValidationError', async t => {
   const p2p = createDb()
   await p2p.ready()
   const metadata = {
@@ -49,7 +49,7 @@ test('init: creation should fail due to missing params', async t => {
     await p2p.init(metadata)
   } catch (err) {
     t.ok(err, 'An error should happen')
-    t.strictEqual(err.message, 'title is required')
+    t.ok(err instanceof SDK.errors.ValidationError, 'It should be a custom SDK error')
     t.end()
     await p2p.destroy()
   }
@@ -107,13 +107,35 @@ test('set: update a value', async t => {
   const metadata = await p2p.init(sampleData)
   const key = metadata.url.toString('hex')
 
-  metadata.description = 'A more accurate description'
-  await p2p.set(metadata)
+  const description = 'A more accurate description'
+  await p2p.set({ url: key, description })
   const result = await p2p.get(key)
 
-  t.same(result.description, metadata.description)
+  t.same(result.description, description)
   t.end()
   await p2p.destroy()
+})
+
+test('set: should throw InvalidKeyError with invalid update', async t => {
+  const p2p = createDb()
+  await p2p.ready()
+  const sampleData = {
+    type: 'content',
+    title: 'demo',
+    description: 'lorem ipsum'
+  }
+  const metadata = await p2p.init(sampleData)
+  const key = metadata.url.toString('hex')
+
+  const license = 'anewkey123456'
+
+  p2p.set({ url: key, license }).catch(err => {
+    t.ok(
+      err instanceof SDK.errors.InvalidKeyError,
+      'error should be instance of InvalidKeyError'
+    )
+    t.end()
+  })
 })
 
 test('update: check version change', async t => {
@@ -129,11 +151,11 @@ test('update: check version change', async t => {
 
   const result1 = await p2p.get(key, false)
 
-  metadata.description = 'A more accurate description'
-  await p2p.set(metadata)
+  const description = 'A more accurate description'
+  await p2p.set({ url: key, description })
   const result2 = await p2p.get(key, false)
 
-  t.same(result2.rawJSON.description, metadata.description)
+  t.same(result2.rawJSON.description, description)
   t.ok(
     result2.version > result1.version,
     'latest version should be bigger than previous version after update'


### PR DESCRIPTION
This PR closes #21 

Introduces 3 types of errors (open to change/edit according to feedback):
- ValidationError -> bad params
- InvalidKeyError -> some properties are read only, happens mostly on updates.
- MissingParam -> indicates that something is missing

