### PR TITLE
New: unpublish method

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Remove content from a profile.
 
 > _async_ `delete(key: string or buffer)`
 
-Remove module from local db and seed db. If it was open in memory, its closed.
+Remove module from local db and seed db. If it was open in memory, its closed. Note: While this will stop the file from being seeded, that does not means that the content won't still be available on the network. This is due to the P2P file sharing dynamics.
 
 ### destroy
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,23 @@ Used to obtain a file descriptor from the `main` file of a module.
 - type: indicates the module type to retrieve. Allowed values: `profile`, `content`.
 - key: represents the module key (`url`) to be looked for. It is the buffer archive key `.toString('hex')`
 
-### register
+### publish
 
-> _async_ `register(contentKey: string or buffer, profileKey: string or buffer)`
+> _async_ `publish(contentKey: string or buffer, profileKey: string or buffer)`
 
 Register new content into a profile. The new content is added to the profile's `p2pcommons.contents`.
+
+### unpublish
+
+> _async_ `unpublish(contentKey: string or buffer, profileKey: string or buffer)`
+
+Remove content from a profile.
+
+### delete
+
+> _async_ `delete(key: string or buffer)`
+
+Remove module from local db and seed db. If it was open in memory, its closed.
 
 ### destroy
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -53,12 +53,12 @@ process.once('SIGINT', () => commons.destroy())
   console.log('Profiles length', allProfiles.length)
 
   const prof = allProfiles[0].rawJSON
-  // register external dat to a local profile
+  // publish external dat to a local profile
   const externalContentUrl = process.argv[2]
   if (externalContentUrl) {
-    console.log('Registering content...', externalContentUrl)
-    await commons.register(externalContentUrl, prof.url)
-    console.log('content registered successfully')
+    console.log('Publishing content...', externalContentUrl)
+    await commons.publish(externalContentUrl, prof.url)
+    console.log('content published successfully')
   }
 
   const { rawJSON: profileUpdated } = await commons.get(prof.url)

--- a/index.js
+++ b/index.js
@@ -849,7 +849,7 @@ class SDK {
   }
 
   /**
-   * register a content module to a profile
+   * publish a content module to a profile
    *
    * @public
    * @async
@@ -930,7 +930,7 @@ class SDK {
 
     // publish new content
     if (profile.p2pcommons.contents.includes(cKeyVersion)) {
-      this._log('publish: Content was already published')
+      this._log('publish: Content was already published', 'warn')
       return
     }
 
@@ -940,7 +940,8 @@ class SDK {
       url: profile.url,
       contents: profile.p2pcommons.contents
     })
-    debug('publish: profile updated successfully')
+
+    this._log('publish: profile updated successfully')
   }
 
   /**
@@ -998,13 +999,13 @@ class SDK {
     const { module: profile, metadata } = await this._getModule(profileKey)
 
     if (!metadata.isWritable) {
-      this._log('profile is not writable', 'warn')
-      return
+      throw new Error('profile is not writable')
     }
 
     if (!profile) {
-      this._log(`profile with key ${DatEncoding.encode(profileKey)} not found`)
-      return
+      throw new Error(
+        `profile with key ${DatEncoding.encode(profileKey)} not found`
+      )
     }
 
     const { host: cKey, version: contentVersion } = parse(contentKey)
@@ -1065,6 +1066,9 @@ class SDK {
       const drive = this.drives.get(dkey) // if drive is open in memory we can close it
       if (drive) {
         await drive.close()
+      }
+      if (!this.disableSwarm) {
+        this.networker.unseed(dkey)
       }
     } catch (err) {
       debug('delete: %O', err)


### PR DESCRIPTION
This PR adds a new method: `unpublish`. It also renames the register method to `publish`. 

Closes #73 

Notes: 
- the method is checking if the profile is writable, if it isn't it will return (displays a message only if verbose mode is enabled). We can throw an error too.
- the SDK is not keeping a single "user profile". It creates modules that can be `content` or `profile`. 