### PR TITLE
Update: changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2020-06-30
 ### Changed
 - renamed (un)publish to (de)register
 - renamed dat.json to index.json
@@ -70,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ready method call is now implicit
 - extra params now throw validationError
 
-[Unreleased]: https://github.com/p2pcommons/sdk-js/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/p2pcommons/sdk-js/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/p2pcommons/sdk-js/compare/v0.5.8...v0.6.0
 [0.5.8]: https://github.com/p2pcommons/sdk-js/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/p2pcommons/sdk-js/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/p2pcommons/sdk-js/compare/v0.5.5...v0.5.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pcommons/sdk-js",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "description": "The SDK for the p2p commons",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In the past I just usually push the updated changelog together with the tags. It's been a while since the last release, so I might look for a better release strategy. 