### PR TITLE
Key location update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- Location of keys is now `~/.p2pcommons/.hyperdrive` instead of `~/.p2pcommons/.dat` 
+
 ### Fixed
 - listProfiles() only returned writable profiles
 

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ const DEFAULT_SDK_OPTS = {
 const DEFAULT_GLOBAL_SETTINGS = {
   networkDepth: 2,
   defaultProfile: '',
-  keys: '~/.p2pcommons/.dat',
+  keys: '~/.p2pcommons/.hyperdrive',
   sparse: true,
   sparseMetadata: true
 }

--- a/lib/dat-helper.js
+++ b/lib/dat-helper.js
@@ -38,7 +38,7 @@ const getDriveStorage = async ({
     // driveStorage = storageFn(location)
   } else {
     driveStorage = new Corestore(
-      getCoreStore(storageOpts.storageLocation, '.dat'),
+      getCoreStore(storageOpts.storageLocation, '.hyperdrive'),
       corestoreOpts
     )
     await driveStorage.ready()


### PR DESCRIPTION
After merging of https://github.com/p2pcommons/specs/pull/49, this PR will make the `sdk-js` up to spec.

Note: It currently was out of spec given that the key folder had been changed to `.hyperdrive` already.

![](https://giphy.com/search/quality)