### PR TITLE
Add cancelable init method

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,6 +155,7 @@ class SDK extends EventEmitter {
     // memoize methods
     this.ready = pMemoize(this.ready)
     // cancelable methods
+    this.init = PCancelable.fn(this.init.bind(this))
     this.clone = PCancelable.fn(this.clone.bind(this))
     // debug constructor
     debug(`platform: ${this.platform}`)


### PR DESCRIPTION
This PR adds a cancelable init() method for the SDK. I am not 100% sure this is the create() function referred to in #192, but if so, closes #192. Otherwise, it also closes #192 because the create method no longer exists and it helps give clarity :blush:﻿
